### PR TITLE
[feat] チャンネル単位で自前の会話履歴（history）を保持する機能を追加

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,7 +56,7 @@ async def chat_command(interaction: discord.Interaction, *, message: str):
         history = session["history"] + [
             {"role": "user", "parts": [message]}]
         
-        response = model.generate_content(message=history)
+        response = model.generate_content(contents=history)
         reply = response.text.strip()
 
         session["history"].append({"role": "user", "parts": [message]})

--- a/main.py
+++ b/main.py
@@ -48,7 +48,8 @@ async def chat_command(interaction: discord.Interaction, *, message: str):
     try:
         if channel_id not in chat_sessions:
             chat_sessions[channel_id] = {
-                "last_active": time.time()
+                "last_active": time.time(),
+                "history": []
             }
         
         session = chat_sessions[channel_id]

--- a/main.py
+++ b/main.py
@@ -15,7 +15,6 @@ GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
 # Gemini設定
 genai.configure(api_key=GEMINI_API_KEY)
 model = genai.GenerativeModel(model_name="models/gemini-2.5-flash-preview-04-17")
-chat = model.start_chat()
 
 # Discord Bot設定
 intents = discord.Intents.default()
@@ -49,15 +48,21 @@ async def chat_command(interaction: discord.Interaction, *, message: str):
     try:
         if channel_id not in chat_sessions:
             chat_sessions[channel_id] = {
-                "chat": model.start_chat(),
                 "last_active": time.time()
             }
         
-        loop = asyncio.get_event_loop()
-        response = await loop.run_in_executor(None, chat_sessions[channel_id]["chat"].send_message, message)
+        session = chat_sessions[channel_id]
+        history = session["history"] + [
+            {"role": "user", "parts": [message]}]
+        
+        response = model.generate_content(message=history)
         reply = response.text.strip()
 
-        chat_sessions[channel_id]['last_active'] = time.time()
+        session["history"].append({"role": "user", "parts": [message]})
+        session["history"].append({"role": "model", "parts": [reply]})
+        session["last_active"] = time.time()
+        session["history"] = session["history"][-20:]  # 最大10ターン分（user+bot
+
 
         formatted = (
             f"👤 {interaction.user.mention} さんが言いました：\n"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved chat session management for enhanced reliability and performance. Conversation history now retains the last 10 turns per session to provide better context in replies. User commands and features remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->